### PR TITLE
Add map hud for basic ray caster

### DIFF
--- a/basic/raycasting.js
+++ b/basic/raycasting.js
@@ -94,8 +94,8 @@ function drawLine(x1, y1, x2, y2, cssColor) {
  * Draw rectangle into screen
  * @param {Number} x1 - x coordinate of rectangle
  * @param {Number} y1 - y coordiante of rectangle
- * @param {Number} w - Width of rectangle
- * @param {Number} h - Height of rectangle
+ * @param {Number} w  - Width of rectangle
+ * @param {Number} h  - Height of rectangle
  * @param {String} cssColor - Color of rectangle
  * @param {Boolean} [fill=false] - Decides whether fill or not
  */
@@ -114,7 +114,7 @@ function drawRect(x1, y1, w, h, cssColor, fill = false) {
  * Draw circle into screen
  * @param {Number} x1 - x coordinate of circle
  * @param {Number} y1 - y coordinate of circle
- * @param {Number} radius - Radius of circle
+ * @param {Number} radius   - Radius of circle
  * @param {String} cssColor - Color of circle
  */
 function drawCircle(x1, y1, radius, cssColor) {
@@ -188,7 +188,7 @@ function rayCasting() {
  * @param {Number} x1 - x coordinate where map will be drawn from
  * @param {Number} y1 - y coordinate where map will be drawn from
  * @param {Number} w  - Width of each rectangle in map
- * @param {Number} h  - Height of each rectangke in map
+ * @param {Number} h  - Height of each rectangle in map
  */
 function drawHudMap(x1 = 0, y1 = 0, w = 10, h = 10) {
     // y/x

--- a/basic/raycasting.js
+++ b/basic/raycasting.js
@@ -13,6 +13,11 @@ let data = {
         incrementAngle: null,
         precision: 64
     },
+    hud: {
+        draw: false,
+        grids: false,
+        transparent: false
+    },
     player: {
         fov: 60,
         halfFov: null,
@@ -71,11 +76,11 @@ function degreeToRadians(degree) {
 
 /**
  * Draw line into screen
- * @param {Number} x1 
- * @param {Number} y1 
- * @param {Number} x2 
- * @param {Number} y2 
- * @param {String} cssColor 
+ * @param {Number} x1 - x coordinate where line will start
+ * @param {Number} y1 - y coordinate where line will start
+ * @param {Number} x2 - x coordinate where line will end
+ * @param {Number} y2 - y coordinate where line will end
+ * @param {String} cssColor - Color of line
  */
 function drawLine(x1, y1, x2, y2, cssColor) {
     screenContext.strokeStyle = cssColor;
@@ -83,6 +88,40 @@ function drawLine(x1, y1, x2, y2, cssColor) {
     screenContext.moveTo(x1, y1);
     screenContext.lineTo(x2, y2);
     screenContext.stroke();
+}
+
+/**
+ * Draw rectangle into screen
+ * @param {Number} x1 - x coordinate of rectangle
+ * @param {Number} y1 - y coordiante of rectangle
+ * @param {Number} w - Width of rectangle
+ * @param {Number} h - Height of rectangle
+ * @param {String} cssColor - Color of rectangle
+ * @param {Boolean} [fill=false] - Decides whether fill or not
+ */
+function drawRect(x1, y1, w, h, cssColor, fill = false) {
+    if (fill == true) {
+        screenContext.fillStyle = cssColor;
+        screenContext.fillRect(x1, y1, w, h);
+    }
+    else {
+        screenContext.strokeStyle = cssColor;
+        screenContext.strokeRect(x1, y1, w, h);
+   }
+}
+
+/**
+ * Draw circle into screen
+ * @param {Number} x1 - x coordinate of circle
+ * @param {Number} y1 - y coordinate of circle
+ * @param {Number} radius - Radius of circle
+ * @param {String} cssColor - Color of circle
+ */
+function drawCircle(x1, y1, radius, cssColor) {
+    screenContext.fillStyle = cssColor;
+    screenContext.beginPath();
+    screenContext.arc(x1, y1, radius, 0, 2 * Math.PI);
+    screenContext.fill();
 }
 
 // Start
@@ -95,6 +134,9 @@ function main() {
     setInterval(function() {
         clearScreen();
         rayCasting();
+        if (data.hud.draw == true) {
+            drawHudMap();
+        }
     }, data.render.delay);
 }
 
@@ -140,6 +182,75 @@ function rayCasting() {
         // Increment
         rayAngle += data.rayCasting.incrementAngle;
     }
+}
+/**
+ * 
+ * @param {Number} x1 - x coordinate where map will be drawn from
+ * @param {Number} y1 - y coordinate where map will be drawn from
+ * @param {Number} w  - Width of each rectangle in map
+ * @param {Number} h  - Height of each rectangke in map
+ */
+function drawHudMap(x1 = 0, y1 = 0, w = 10, h = 10) {
+    // y/x
+    const mapSize = [data.map.length, data.map[0].length];
+    
+    // Draw HUD background
+    if (data.hud.transparent != true) { 
+        drawRect(x1, y1, mapSize[1]*w, mapSize[0]*h, "#e5e5e5", true);
+    }
+
+    let y; 
+    for (y = 0; y < mapSize[0]; y++) { 
+      let x;
+      for (x = 0; x < mapSize[1]; x++) {
+        if (data.map[y][x] == 1) {
+            drawRect(x*w+x1, y*h+y1, w, h, "#7f7f7f", true);
+            // Draw outline for rectangle
+            // https://stackoverflow.com/questions/28057881/javascript-either-strokerect-or-fillrect-blurry-depending-on-translation
+            drawRect(parseInt(x*w+x1)+0.50,parseInt(y*h+y1)+0.50,w,h,"#505050", false);
+        }
+        
+        // Draw grids if requested
+        if (data.hud.grids == true) {
+            drawLine((x*w+x1)+0.50,(y*h+y1)+0.50, (x*w+x1)+0.50, (y*h+y1)+h+0.50, "black");
+        }
+
+      }
+      if (data.hud.grids == true) { 
+          // Draw last vertical line
+          drawLine((x*w+x1)+0.50,(y*h+y1)+0.50, (x*w+x1)+0.50, (y*h+y1)+h+0.50, "black");
+          // Draw horizantal line
+          drawLine(x1+0.50,(y*h+y1)+0.50, (mapSize[1]*w+x1)+0.50, (y*h+y1)+0.50, "black");
+      }
+    }
+    // Draw last horizantal line
+    if (data.hud.grids == true) {
+        drawLine(x1+0.50,(y*h+y1)+0.50, (mapSize[1]*w+x1)+0.50, (y*h+y1)+0.50, "black");
+    }
+
+    // Draw player
+    drawCircle(data.player.x*w+x1, data.player.y*h+y1, 5, "red");
+    // Draw player rays
+    for (let i = data.player.angle - data.player.halfFov; i < data.player.angle + data.player.halfFov; i++) {
+      
+        // Code reuse from rayCasting() function
+        let ray = {
+            x: data.player.x,
+            y: data.player.y
+        }
+
+        let rayCos = Math.cos(degreeToRadians(i)) / data.rayCasting.precision;
+        let raySin = Math.sin(degreeToRadians(i)) / data.rayCasting.precision;
+        
+        let wall = 0;
+        while(wall == 0) {
+            ray.x += rayCos;
+            ray.y += raySin;
+            wall = data.map[Math.floor(ray.y)][Math.floor(ray.x)];
+        }
+        // Draw single ray
+        drawLine(data.player.x*w+x1, data.player.y*h+y1, ray.x*w+x1, ray.y*h+y1, "#f2c772"); 
+    } 
 }
 
 /**


### PR DESCRIPTION
Hi @vinibiavatti1, thank you for tutorial. I liked it. I didn't find minimap in basic raycaster example so I decided to implement it. This minimap can be used anywhere in screen. Minimap disabled as default so it needs to be toggled by user. It has 2 options, grid and transparency. Grid option draws grids over map. Transparency option decides whether you use background or not.
I tried to make it similar as shown in tutorial. 
![sample](https://user-images.githubusercontent.com/78658591/161363529-f8cafa0c-445c-470a-bf95-193346d8a5c1.png)

